### PR TITLE
Ensure README is synched with code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,4 +47,4 @@ repos:
         name: readme.py
         language: system
         entry: python .tools/readme.py
-        files: "README.md|src/changelist/default_config.toml|.tools/readme.py"
+        files: "README.md|src/changelist/default_config.toml|.github/workflows/label-check.yaml|.github/workflows/milestone-merged-prs.yaml|.tools/readme.py"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,11 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+
+  - repo: local
+    hooks:
+      - id: readme.py
+        name: readme.py
+        language: system
+        entry: python .tools/readme.py
+        files: "README.md|src/changelist/default_config.toml|.tools/readme.py"

--- a/.tools/readme.py
+++ b/.tools/readme.py
@@ -35,12 +35,12 @@ def main():
     section = section.replace(r"\\", r"\\\\")
     readme = rx.sub(section, readme)
 
-    # default_config.toml
+    # label-check.yaml
     begin, end, section = get_section_info(".github/workflows/label-check.yaml")
     rx = re.compile(begin + ".*?" + end, re.DOTALL)
     readme = rx.sub(section, readme)
 
-    # default_config.toml
+    # milestone-merged-prs.yaml
     begin, end, section = get_section_info(
         ".github/workflows/milestone-merged-prs.yaml"
     )

--- a/.tools/readme.py
+++ b/.tools/readme.py
@@ -1,20 +1,25 @@
 import re
 
-with open("README.md") as fh:
-    readme = fh.read()
 
-with open("src/changelist/default_config.toml") as fh:
-    default_config = fh.read()
+def main():
+    with open("README.md") as fh:
+        readme = fh.read()
 
-config_begin = r"<!--- begin default_config.toml --->\n"
-config_end = r"<!--- end default_config.toml --->\n"
-config_section = (
-    config_begin + r"\n````toml\n" + default_config + r"````\n\n" + config_end
-)
+    with open("src/changelist/default_config.toml") as fh:
+        default_config = fh.read()
 
-rx = re.compile(config_begin + ".*?" + config_end, re.DOTALL)
-readme = rx.sub(config_section, readme)
+    config_begin = r"<!--- begin default_config.toml --->\n"
+    config_end = r"<!--- end default_config.toml --->\n"
+    config_section = (
+        config_begin + r"\n````toml\n" + default_config + r"````\n\n" + config_end
+    )
+
+    rx = re.compile(config_begin + ".*?" + config_end, re.DOTALL)
+    readme = rx.sub(config_section, readme)
+
+    with open("README.md", "w") as fh:
+        fh.write(readme)
 
 
-with open("README.md", "w") as fh:
-    fh.write(readme)
+if __name__ == "__main__":
+    main()

--- a/.tools/readme.py
+++ b/.tools/readme.py
@@ -6,23 +6,31 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).parent.parent
 
 
+def get_section_info(file):
+    p = Path(file)
+    name = p.parts[-1]
+    ext = p.suffix[1:]
+    begin = rf"<!--- begin {name} --->\n"
+    end = rf"<!--- end {name} --->\n"
+
+    with open(PROJECT_ROOT / file) as fh:
+        section = fh.read()
+        
+    section = (
+        begin + rf"\n````{ext}\n" + section + r"````\n\n" + end
+    )
+    return begin, end, section
+
 def main():
     with open(PROJECT_ROOT / "README.md") as fh:
         readme = fh.read()
 
-    with open(PROJECT_ROOT / "src/changelist/default_config.toml") as fh:
-        default_config = fh.read()
-
-    config_begin = r"<!--- begin default_config.toml --->\n"
-    config_end = r"<!--- end default_config.toml --->\n"
-    config_section = (
-        config_begin + r"\n````toml\n" + default_config + r"````\n\n" + config_end
-    )
-
-    rx = re.compile(config_begin + ".*?" + config_end, re.DOTALL)
+    # default_config.toml
+    begin, end, section = get_section_info("src/changelist/default_config.toml")
+    rx = re.compile(begin + ".*?" + end, re.DOTALL)
     # Regex substitution replaces r"\\" with to r"\", compensate
-    config_section = config_section.replace(r"\\", r"\\\\")
-    readme = rx.sub(config_section, readme)
+    section = section.replace(r"\\", r"\\\\")
+    readme = rx.sub(section, readme)
 
     with open(PROJECT_ROOT / "README.md", "w") as fh:
         fh.write(readme)

--- a/.tools/readme.py
+++ b/.tools/readme.py
@@ -1,0 +1,20 @@
+import re
+
+with open("README.md") as fh:
+    readme = fh.read()
+
+with open("src/changelist/default_config.toml") as fh:
+    default_config = fh.read()
+
+config_begin = r"<!--- begin default_config.toml --->\n"
+config_end = r"<!--- end default_config.toml --->\n"
+config_section = (
+    config_begin + r"\n````toml\n" + default_config + r"````\n\n" + config_end
+)
+
+rx = re.compile(config_begin + ".*?" + config_end, re.DOTALL)
+readme = rx.sub(config_section, readme)
+
+
+with open("README.md", "w") as fh:
+    fh.write(readme)

--- a/.tools/readme.py
+++ b/.tools/readme.py
@@ -32,6 +32,16 @@ def main():
     section = section.replace(r"\\", r"\\\\")
     readme = rx.sub(section, readme)
 
+    # default_config.toml
+    begin, end, section = get_section_info(".github/workflows/label-check.yaml")
+    rx = re.compile(begin + ".*?" + end, re.DOTALL)
+    readme = rx.sub(section, readme)
+
+    # default_config.toml
+    begin, end, section = get_section_info(".github/workflows/milestone-merged-prs.yaml")
+    rx = re.compile(begin + ".*?" + end, re.DOTALL)
+    readme = rx.sub(section, readme)
+
     with open(PROJECT_ROOT / "README.md", "w") as fh:
         fh.write(readme)
 

--- a/.tools/readme.py
+++ b/.tools/readme.py
@@ -17,6 +17,8 @@ def main():
     )
 
     rx = re.compile(config_begin + ".*?" + config_end, re.DOTALL)
+    # Regex substitution replaces r"\\" with to r"\", compensate
+    config_section = config_section.replace(r"\\", r"\\\\")
     readme = rx.sub(config_section, readme)
 
     with open("README.md", "w") as fh:

--- a/.tools/readme.py
+++ b/.tools/readme.py
@@ -1,3 +1,5 @@
+"""Update README.md, used by pre-commit."""
+
 import re
 
 

--- a/.tools/readme.py
+++ b/.tools/readme.py
@@ -1,13 +1,16 @@
 """Update README.md, used by pre-commit."""
 
 import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
 
 
 def main():
-    with open("README.md") as fh:
+    with open(PROJECT_ROOT / "README.md") as fh:
         readme = fh.read()
 
-    with open("src/changelist/default_config.toml") as fh:
+    with open(PROJECT_ROOT / "src/changelist/default_config.toml") as fh:
         default_config = fh.read()
 
     config_begin = r"<!--- begin default_config.toml --->\n"
@@ -21,7 +24,7 @@ def main():
     config_section = config_section.replace(r"\\", r"\\\\")
     readme = rx.sub(config_section, readme)
 
-    with open("README.md", "w") as fh:
+    with open(PROJECT_ROOT / "README.md", "w") as fh:
         fh.write(readme)
 
 

--- a/.tools/readme.py
+++ b/.tools/readme.py
@@ -15,11 +15,14 @@ def get_section_info(file):
 
     with open(PROJECT_ROOT / file) as fh:
         section = fh.read()
-        
-    section = (
-        begin + rf"\n````{ext}\n" + section + r"````\n\n" + end
-    )
+
+    if ext == "toml":
+        section = begin + rf"\n````{ext}\n" + section + r"````\n\n" + end
+    else:
+        section = begin + rf"\n```{ext}\n" + section + r"```\n\n" + end
+
     return begin, end, section
+
 
 def main():
     with open(PROJECT_ROOT / "README.md") as fh:
@@ -38,7 +41,9 @@ def main():
     readme = rx.sub(section, readme)
 
     # default_config.toml
-    begin, end, section = get_section_info(".github/workflows/milestone-merged-prs.yaml")
+    begin, end, section = get_section_info(
+        ".github/workflows/milestone-merged-prs.yaml"
+    )
     rx = re.compile(begin + ".*?" + end, re.DOTALL)
     readme = rx.sub(section, readme)
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ we recommend adding an action that fails CI if the label is missing.
 
 To do so, place the following in `.github/workflows/label-check.yaml`:
 
+<!--- Changes to the following block are overridden by a pre-commit hook! --->
+<!--- begin label-check.yaml --->
+
 ```yaml
 name: Labels
 
@@ -151,6 +154,8 @@ jobs:
         run: exit 1
 ```
 
+<!--- end label-check.yaml --->
+
 ### Milestones
 
 Often, it is helpful to have milestones that reflect the actual PRs
@@ -158,6 +163,9 @@ merged. We therefore recommend adding an action that attached the
 next open milestone to any merged PR.
 
 To do so, place the following in `.github/workflows/milestone-merged-prs.yaml`:
+
+<!--- Changes to the following block are overridden by a pre-commit hook! --->
+<!--- begin milestone-merged-prs.yaml --->
 
 ```yaml
 name: Milestone
@@ -179,5 +187,7 @@ jobs:
           token: ${{ secrets.MILESTONE_LABELER_TOKEN }}
           force: true
 ```
+
+<!--- end milestone-merged-prs.yaml --->
 
 See https://github.com/scientific-python/attach-next-milestone-action for more information.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ changelist can be configured from two sources, in order of precedence:
 If a configuration option is not specified in either file above, changelist
 falls back to the following configuration:
 
+<!--- Changes to the following block are overridden by a pre-commit hook! --->
 <!--- begin default_config.toml --->
 
 ````toml

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ changelist can be configured from two sources, in order of precedence:
 If a configuration option is not specified in either file above, changelist
 falls back to the following configuration:
 
+<!--- begin default_config.toml --->
+
 ````toml
 # Default changelist configuration as supported in pyproject.toml
 [tool.changelist]
@@ -108,6 +110,8 @@ pr_summary_regex = "^```release-note\\s*(?P<summary>[\\s\\S]*?\\w[\\s\\S]*?)\\s*
 ".*Infrastructure.*" = "Infrastructure"
 ".*Maintenance.*" = "Maintenance"
 ````
+
+<!--- end default_config.toml --->
 
 ## Set up your repository
 

--- a/README.md
+++ b/README.md
@@ -130,14 +130,14 @@ To do so, place the following in `.github/workflows/label-check.yaml`:
 <!--- Changes to the following block are overridden by a pre-commit hook! --->
 <!--- begin label-check.yaml --->
 
-```yaml
+````yaml
 name: Labels
 
 on:
   pull_request:
     types:
       - opened
-      - repoened
+      - reopened
       - labeled
       - unlabeled
       - synchronize
@@ -152,7 +152,7 @@ jobs:
     steps:
       - if: "contains( env.LABELS, 'type: ' ) == false"
         run: exit 1
-```
+````
 
 <!--- end label-check.yaml --->
 
@@ -167,7 +167,7 @@ To do so, place the following in `.github/workflows/milestone-merged-prs.yaml`:
 <!--- Changes to the following block are overridden by a pre-commit hook! --->
 <!--- begin milestone-merged-prs.yaml --->
 
-```yaml
+````yaml
 name: Milestone
 
 on:
@@ -186,7 +186,7 @@ jobs:
         with:
           token: ${{ secrets.MILESTONE_LABELER_TOKEN }}
           force: true
-```
+````
 
 <!--- end milestone-merged-prs.yaml --->
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To do so, place the following in `.github/workflows/label-check.yaml`:
 <!--- Changes to the following block are overridden by a pre-commit hook! --->
 <!--- begin label-check.yaml --->
 
-````yaml
+```yaml
 name: Labels
 
 on:
@@ -152,7 +152,7 @@ jobs:
     steps:
       - if: "contains( env.LABELS, 'type: ' ) == false"
         run: exit 1
-````
+```
 
 <!--- end label-check.yaml --->
 
@@ -167,7 +167,7 @@ To do so, place the following in `.github/workflows/milestone-merged-prs.yaml`:
 <!--- Changes to the following block are overridden by a pre-commit hook! --->
 <!--- begin milestone-merged-prs.yaml --->
 
-````yaml
+```yaml
 name: Milestone
 
 on:
@@ -186,7 +186,7 @@ jobs:
         with:
           token: ${{ secrets.MILESTONE_LABELER_TOKEN }}
           force: true
-````
+```
 
 <!--- end milestone-merged-prs.yaml --->
 


### PR DESCRIPTION
Following up on a suggestion by @bsipocz https://github.com/scientific-python/changelist/pull/30#discussion_r1343029878.

There is an issue with string literals in the toml file.

![2023-10-02T21:15:36,110408044-07:00](https://github.com/scientific-python/changelist/assets/123428/51d6e3d0-bfd2-4d54-bc2c-3d7f1583b0c8)


If this approach seems reasonable, we may want to do the same thing for:
- [ ] .github/workflows/label-check.yaml
- [ ] .github/workflows/milestone-merged-prs.yaml