### PR TITLE
Add newline after release title

### DIFF
--- a/src/changelist/_format.py
+++ b/src/changelist/_format.py
@@ -49,6 +49,7 @@ class MdFormatter:
             repo_name=self.repo_name, version=self.version
         )
         yield from self._format_section_title(title, level=1)
+        yield "\n"
         yield from self._format_intro()
         for title, pull_requests in self._prs_by_section.items():
             yield from self._format_pr_section(title, pull_requests)


### PR DESCRIPTION
Before changelist produced
```
# scientific-python-hugo-theme 0.3
We're happy to announce the release of scientific-python-hugo-theme 0.3!
```
This PR produces
``` 
# scientific-python-hugo-theme 0.3

We're happy to announce the release of scientific-python-hugo-theme 0.3!
```

See https://github.com/scientific-python/scientific-python-hugo-theme/pull/343.