### PR TITLE
Make README intro more succinct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,15 @@
 # changelist
 
-Changelist helps you write better release notes by automating as much of the
-process as possible. For example, see
+A tool that automates release note generation.
+
+For example, see
 https://github.com/scientific-python/changelist/blob/main/CHANGELOG.md.
 
 **Features**
 
-- Compile a list of pull requests, code authors and reviewers between any two
-  valid Git objects (refs).
+- Compile a list of pull requests, code authors, and reviewers between
+  two given git commits.
 - Categorize pull requests into sections based on GitHub labels.
-- Point it at any repository on GitHub. No need to clone or checkout a
-  repository locally, a Python package is all that's needed.
-
-We recommend to treat the generated document as a first draft to build
-on and not as an already perfect documentation of the release.
 
 _This project is currently in its alpha stage and might be incomplete or change a lot!_
 


### PR DESCRIPTION
New users / developers often scan a README to figure out what a package does and whether they need it. This PR aims to reduce the amount of upfront text, focusing on the key characteristics of the package.

I've removed the text about release notes not being perfect because (a) developers know they can edit release notes and (b) probably also know that they shouldn't spend much time doing that ;)