### PR TITLE
Ignore PRs by specified usernames in the generated changelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,17 @@ _These lists are automatically generated, and may not be complete or may contain
 duplicates._
 """
 
-# Profiles that are excluded from the contributor list.
+# Usernames that are excluded from the contributor list. This may also ignore
+# pull request of these users (see field `ignore_prs_by_username`).
 ignored_user_logins = [
     "web-flow",
+]
+
+# Ignore pull requests authored by these users.
+# If `{include = "ignored_user_logins"}` is included in this list (the default),
+# usernames from the field `ignored_user_logins` are also included.
+ignore_prs_by_username = [
+    {include = "ignored_user_logins"},
 ]
 
 # If this regex matches a pull requests description, the captured content
@@ -228,7 +236,7 @@ jobs:
     name: attach to PR
     runs-on: ubuntu-latest
     steps:
-      - uses: scientific-python/attach-next-milestone-action@bc07be829f693829263e57d5e8489f4e57d3d420
+      - uses: scientific-python/attach-next-milestone-action@c9cfab10ad0c67fed91b01103db26b7f16634639
         with:
           token: ${{ secrets.MILESTONE_LABELER_TOKEN }}
           force: true

--- a/src/changelist/_cli.py
+++ b/src/changelist/_cli.py
@@ -157,7 +157,7 @@ def main(
         pull_requests,
         pr_summary_regex=config["pr_summary_regex"],
         pr_summary_label_regex=config["pr_summary_label_regex"],
-        ignored_user_logins=tuple(config["ignored_user_logins"]),
+        ignore_prs_by_username=config["ignore_prs_by_username"],
     )
 
     Formatter = {"md": MdFormatter, "rst": RstFormatter}[format]

--- a/src/changelist/_cli.py
+++ b/src/changelist/_cli.py
@@ -157,6 +157,7 @@ def main(
         pull_requests,
         pr_summary_regex=config["pr_summary_regex"],
         pr_summary_label_regex=config["pr_summary_label_regex"],
+        ignored_user_logins=tuple(config["ignored_user_logins"]),
     )
 
     Formatter = {"md": MdFormatter, "rst": RstFormatter}[format]

--- a/src/changelist/_config.py
+++ b/src/changelist/_config.py
@@ -13,6 +13,28 @@ logger = logging.getLogger(__name__)
 DEFAULT_CONFIG_PATH = Path(__file__).parent / "default_config.toml"
 
 
+def _dereference_ignore_prs_by_username(config: dict) -> dict:
+    """Dereference "include" in `ignore_prs_by_username` field.
+
+    Example:
+    >>> config = {
+    ...     "ignored_user_logins": ["bot"],
+    ...     "ignore_prs_by_username": [{"include": "ignored_user_logins"}, "web-flow"]
+    ... }
+    >>> _dereference_ignore_prs_by_username(config)
+    {'ignored_user_logins': ['bot'], 'ignore_prs_by_username': ['web-flow', 'bot']}
+    """
+    if "ignore_prs_by_username" not in config:
+        return config
+
+    include_sentinel = {"include": "ignored_user_logins"}
+    if include_sentinel in config["ignore_prs_by_username"]:
+        config["ignore_prs_by_username"].remove(include_sentinel)
+        config["ignore_prs_by_username"] += config.get("ignored_user_logins", [])
+
+    return config
+
+
 def remote_config(gh: Github, org_repo: str, *, rev: str):
     """Return configuration options in remote pyproject.toml if they exist."""
     repo = gh.get_repo(org_repo)
@@ -24,6 +46,7 @@ def remote_config(gh: Github, org_repo: str, *, rev: str):
         content = ""
     config = tomllib.loads(content)
     config = config.get("tool", {}).get("changelist", {})
+    config = _dereference_ignore_prs_by_username(config)
     return config
 
 
@@ -32,6 +55,7 @@ def local_config(path: Path) -> dict:
     with path.open("rb") as fp:
         config = tomllib.load(fp)
     config = config.get("tool", {}).get("changelist", {})
+    config = _dereference_ignore_prs_by_username(config)
     return config
 
 

--- a/src/changelist/_config.py
+++ b/src/changelist/_config.py
@@ -46,7 +46,6 @@ def remote_config(gh: Github, org_repo: str, *, rev: str):
         content = ""
     config = tomllib.loads(content)
     config = config.get("tool", {}).get("changelist", {})
-    config = _dereference_ignore_prs_by_username(config)
     return config
 
 
@@ -55,7 +54,6 @@ def local_config(path: Path) -> dict:
     with path.open("rb") as fp:
         config = tomllib.load(fp)
     config = config.get("tool", {}).get("changelist", {})
-    config = _dereference_ignore_prs_by_username(config)
     return config
 
 
@@ -74,4 +72,5 @@ def add_config_defaults(
         if key not in config:
             config[key] = value
             logger.debug("using default config value for %s", key)
+    config = _dereference_ignore_prs_by_username(config)
     return config

--- a/src/changelist/_objects.py
+++ b/src/changelist/_objects.py
@@ -27,7 +27,7 @@ class ChangeNote:
         *,
         pr_summary_regex: str,
         pr_summary_label_regex: str,
-        ignored_user_logins: tuple[str, ...] = (),
+        ignore_prs_by_username: list[str] | None = None,
     ) -> "set[ChangeNote]":
         """Create a set of notes from pull requests.
 
@@ -41,15 +41,18 @@ class ChangeNote:
         a change that would be described in a single note, this is often not
         the case.
 
-        `ignored_user_logins` is a list of user logins whose pull requests
+        `ignore_prs_by_username` is a list of user logins whose pull requests
         should be excluded from the changelog entirely.
         """
+        if ignore_prs_by_username is None:
+            ignore_prs_by_username = []
+
         pr_summary_regex = re.compile(pr_summary_regex, flags=re.MULTILINE)
         pr_summary_label_regex = re.compile(pr_summary_label_regex)
 
         notes = set()
         for pr in pull_requests:
-            if pr.user and pr.user.login in ignored_user_logins:
+            if pr.user and pr.user.login in ignore_prs_by_username:
                 logger.debug(
                     "skipping PR %s from ignored user %s",
                     pr.html_url,

--- a/src/changelist/_objects.py
+++ b/src/changelist/_objects.py
@@ -2,7 +2,7 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Union
+from typing import Optional, Union
 
 from github.NamedUser import NamedUser
 from github.PullRequest import PullRequest
@@ -27,7 +27,7 @@ class ChangeNote:
         *,
         pr_summary_regex: str,
         pr_summary_label_regex: str,
-        ignore_prs_by_username: list[str] | None = None,
+        ignore_prs_by_username: Optional[list[str]] = None,
     ) -> "set[ChangeNote]":
         """Create a set of notes from pull requests.
 

--- a/src/changelist/_objects.py
+++ b/src/changelist/_objects.py
@@ -27,6 +27,7 @@ class ChangeNote:
         *,
         pr_summary_regex: str,
         pr_summary_label_regex: str,
+        ignored_user_logins: tuple[str, ...] = (),
     ) -> "set[ChangeNote]":
         """Create a set of notes from pull requests.
 
@@ -39,12 +40,22 @@ class ChangeNote:
         requests and notes somewhat. While ideally, a pull request introduces
         a change that would be described in a single note, this is often not
         the case.
+
+        `ignored_user_logins` is a list of user logins whose pull requests
+        should be excluded from the changelog entirely.
         """
         pr_summary_regex = re.compile(pr_summary_regex, flags=re.MULTILINE)
         pr_summary_label_regex = re.compile(pr_summary_label_regex)
 
         notes = set()
         for pr in pull_requests:
+            if pr.user and pr.user.login in ignored_user_logins:
+                logger.debug(
+                    "skipping PR %s from ignored user %s",
+                    pr.html_url,
+                    pr.user.login,
+                )
+                continue
             pr_labels = tuple(label.name for label in pr.labels)
 
             if not pr.body or not (

--- a/src/changelist/default_config.toml
+++ b/src/changelist/default_config.toml
@@ -21,9 +21,17 @@ _These lists are automatically generated, and may not be complete or may contain
 duplicates._
 """
 
-# Profiles that are excluded from the contributor list.
+# Usernames that are excluded from the contributor list. This may also ignore
+# pull request of these users (see field `ignore_prs_by_username`).
 ignored_user_logins = [
     "web-flow",
+]
+
+# Ignore pull requests authored by these users.
+# If `{include = "ignored_user_logins"}` is included in this list (the default),
+# usernames from the field `ignored_user_logins` are also included.
+ignore_prs_by_username = [
+    {include = "ignored_user_logins"},
 ]
 
 # If this regex matches a pull requests description, the captured content

--- a/test/test_objects.py
+++ b/test/test_objects.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Union
@@ -10,6 +10,13 @@ here = Path(__file__).parent
 
 
 DEFAULT_CONFIG = local_config(DEFAULT_CONFIG_PATH)
+
+
+@dataclass
+class _MockUser:
+    """Mocks github.User partially."""
+
+    login: str
 
 
 @dataclass
@@ -26,6 +33,7 @@ class _MockPullRequest:
     title: str
     body: Union[str, None]
     labels: list[_MockLabel]
+    user: _MockUser = field(default_factory=lambda: _MockUser(login="friendlyDev"))
     number: int = (42,)
     html_url: str = "https://github.com/scientific-python/changelist/pull/53"
     merged_at: datetime = datetime(2024, 1, 1)
@@ -72,6 +80,40 @@ Make `is_odd()` work for negative numbers.
         assert len(caplog.records) == 1
         assert caplog.records[0].levelname == "DEBUG"
         assert "falling back to PR labels for summary" in caplog.records[0].msg
+
+    def test_from_pull_requests_ignore_by_username(self, caplog):
+        caplog.set_level("DEBUG")
+        pull_requests = [
+            _MockPullRequest(
+                title="PR from user",
+                body=None,
+                labels=[_MockLabel("Documentation")],
+                user=_MockUser("someDev"),
+            ),
+            _MockPullRequest(
+                title="PR from bot",
+                body=None,
+                labels=[_MockLabel("Documentation")],
+                user=_MockUser("bot"),
+            ),
+        ]
+        notes = ChangeNote.from_pull_requests(
+            pull_requests,
+            pr_summary_regex=DEFAULT_CONFIG["pr_summary_regex"],
+            pr_summary_label_regex=DEFAULT_CONFIG["pr_summary_label_regex"],
+            ignore_prs_by_username=["bot"],
+        )
+        assert len(notes) == 1
+        notes = list(notes)
+        assert notes[0].content == "PR from user"
+        assert notes[0].labels == ("Documentation",)
+
+        assert len(caplog.records) == 2
+        assert caplog.records[0].levelname == "DEBUG"
+        assert "falling back to title" in caplog.records[0].msg
+
+        assert caplog.records[1].levelname == "DEBUG"
+        assert "skipping PR %s from ignored user %s" in caplog.records[1].msg
 
     def test_from_pull_requests_fallback_title(self, caplog):
         caplog.set_level("DEBUG")


### PR DESCRIPTION
> [!NOTE]
> This PR is a draft, and its description is a stub. I'll update it soon! 

Closes #83

TODO:
- [x] add tests
- [x] update README
- [x] do a sanity check once —> @stefanv did this in https://github.com/scientific-python/changelist/pull/85#issuecomment-3610623422; thanks :)

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
By default, hide pull requests that are authored by users / bots given in
the config field `ignored_user_logins. This behavior can be overridden by
explicitly specifying the new config field `ignore_prs_by_username`.
``` 